### PR TITLE
Use auto inlineStylesheets for shared CSS caching

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,7 +8,7 @@ export default defineConfig({
   integrations: [tailwind()],
   output: 'static',
   build: {
-    inlineStylesheets: 'always',
+    inlineStylesheets: 'auto',
     assets: 'assets',
     minify: true,
     splitting: true,


### PR DESCRIPTION
## Summary
- allow Astro to extract shared CSS by switching `inlineStylesheets` build option to `auto`

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b6532d80688323bcc14ddf383136ff